### PR TITLE
pi button can be used for operations other than multiplication

### DIFF
--- a/pyCalc/gui.py
+++ b/pyCalc/gui.py
@@ -109,7 +109,7 @@ class TkGUI(tk.Tk):
 
 		# adding new operations
 		pi = tk.Button(self, text="pi", command=lambda: self.get_operation(
-			"*3.14"), font=self.FONT_LARGE)
+			"3.14"), font=self.FONT_LARGE)
 		pi.grid(row=2, column=4)
 		modulo = tk.Button(
 			self, text="%", command=lambda:  self.get_operation("%"), font=self.FONT_LARGE)


### PR DESCRIPTION
On clicking the pi button it always considered that the user wants to multiply a number with pi(3.14). By removing the '*' operator the pi button becomes more general purpose by just using the value of pi and giving the user the discretion of choosing the kind of operator he needs to work along with the value of pi provided with the pi button. 